### PR TITLE
replaced lazy_static with OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "sanitize-filename"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,25 +12,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -40,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -51,20 +42,13 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "sanitize-filename"
 version = "0.5.0"
 dependencies = [
- "lazy_static",
  "regex",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,13 @@ version = "0.5.0"
 keywords = ["filename", "sanitizer"]
 license = "MIT"
 readme = "README.md"
+edition = "2021"
+rust-version = "1.70.0"
 repository = "https://github.com/kardeiz/sanitize-filename"
 description = "A simple filename sanitizer, based on Node's sanitize-filename"
 
 [dependencies]
-lazy_static = "1"
-regex = { version = "1.9", default-features = false, features = ["std", "unicode-case"] }
+regex = { version = "1.11", default-features = false, features = [
+    "std",
+    "unicode-case",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jacob Brown <kardeiz@gmail.com>"]
 name = "sanitize-filename"
-version = "0.5.0"
+version = "0.6.0"
 keywords = ["filename", "sanitizer"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Replaced lazy_static with once lock, this gets rid of the lazy_static dependency.

- bumped version to 0.6.0
- replaced lazy_static with OnceLock
- set edition to 2021 and required rust version to 1.70.0
- updated the regex dependency to the most recent version

All tests succeed.